### PR TITLE
Add safeguard for omission of `new` keyword on constructors.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = tab
+indent_size = 2

--- a/lib/classes/AbstractController.js
+++ b/lib/classes/AbstractController.js
@@ -19,7 +19,7 @@ var AbstractViewableService = require('./AbstractViewableService'),
  */
 function AbstractController() {
 
-  if (!(this instanceof this)) {
+  if (!(this instanceof AbstractController)) {
 		return applyConstructor(AbstractController, arguments);
   }
 

--- a/lib/classes/AbstractController.js
+++ b/lib/classes/AbstractController.js
@@ -7,7 +7,9 @@
 
 
 // local modules
-var AbstractViewableService = require('./AbstractViewableService');
+var AbstractViewableService = require('./AbstractViewableService'),
+	applyConstructor = require('../utils/applyConstructor');
+
 
 
 /**
@@ -16,6 +18,11 @@ var AbstractViewableService = require('./AbstractViewableService');
  * @constructor
  */
 function AbstractController() {
+
+  if (!(this instanceof this)) {
+		return applyConstructor(AbstractController, arguments);
+  }
+
 	// controllers need the same foundation as viewable services
 	AbstractViewableService.apply(this, arguments);
 

--- a/lib/classes/AbstractDirective.js
+++ b/lib/classes/AbstractDirective.js
@@ -8,7 +8,9 @@
 
 // local modules
 var AbstractService = require('./AbstractService'),
-	AbstractViewableService = require('./AbstractViewableService');
+	AbstractViewableService = require('./AbstractViewableService'),
+	applyConstructor = require('../utils/applyConstructor');
+
 
 
 /**
@@ -16,6 +18,10 @@ var AbstractService = require('./AbstractService'),
  * @constructor
  */
 function AbstractDirective() {
+
+  if (!(this instanceof this)) {
+		return applyConstructor(AbstractService, arguments);
+  }
 
 	// directives need the same foundation as viewable services
 	AbstractViewableService.apply(this, arguments);

--- a/lib/classes/AbstractDirective.js
+++ b/lib/classes/AbstractDirective.js
@@ -19,7 +19,7 @@ var AbstractService = require('./AbstractService'),
  */
 function AbstractDirective() {
 
-  if (!(this instanceof this)) {
+  if (!(this instanceof AbstractDirective)) {
 		return applyConstructor(AbstractService, arguments);
   }
 

--- a/lib/classes/AbstractDirective.js
+++ b/lib/classes/AbstractDirective.js
@@ -20,7 +20,7 @@ var AbstractService = require('./AbstractService'),
 function AbstractDirective() {
 
   if (!(this instanceof AbstractDirective)) {
-		return applyConstructor(AbstractService, arguments);
+		return applyConstructor(AbstractDirective, arguments);
   }
 
 	// directives need the same foundation as viewable services

--- a/lib/classes/AbstractFilter.js
+++ b/lib/classes/AbstractFilter.js
@@ -24,7 +24,7 @@ var AbstractService = require('./AbstractService'),
  */
 function AbstractFilter() {
 
-  if (!(this instanceof this)) {
+  if (!(this instanceof AbstractFilter)) {
 		return applyConstructor(AbstractFilter, arguments);
   }
 

--- a/lib/classes/AbstractFilter.js
+++ b/lib/classes/AbstractFilter.js
@@ -7,7 +7,8 @@
 
 
 // local modules
-var AbstractService = require('./AbstractService');
+var AbstractService = require('./AbstractService'),
+	applyConstructor = require('../utils/applyConstructor');
 
 /**
  * AbstractFilter provides an abstraction for filters
@@ -22,6 +23,11 @@ var AbstractService = require('./AbstractService');
  * @constructor
  */
 function AbstractFilter() {
+
+  if (!(this instanceof this)) {
+		return applyConstructor(AbstractFilter, arguments);
+  }
+
 	AbstractService.apply(this, arguments);
 }
 
@@ -32,7 +38,7 @@ function AbstractFilter() {
  */
 AbstractFilter.$factory = function(construct) {
 	var func = function() {
-		var obj = new construct;
+		var obj = new construct();
 		if (obj instanceof AbstractService) {
 			obj.injectServices.apply(obj, arguments);
 		}

--- a/lib/classes/AbstractService.js
+++ b/lib/classes/AbstractService.js
@@ -5,12 +5,20 @@
 
 'use strict';
 
+var applyConstructor = require('../utils/applyConstructor');
+
+
 
 /**
  * AbstractService provides common functionality for all services
  * @constructor
  */
 function AbstractService() {
+
+  if (!(this instanceof this)) {
+		return applyConstructor(AbstractService, arguments);
+  }
+
 	this._services = {};
 	if (arguments.length !== 0) {
 		this.injectServices.apply(this, arguments);

--- a/lib/classes/AbstractService.js
+++ b/lib/classes/AbstractService.js
@@ -15,7 +15,7 @@ var applyConstructor = require('../utils/applyConstructor');
  */
 function AbstractService() {
 
-  if (!(this instanceof this)) {
+  if (!(this instanceof AbstractService)) {
 		return applyConstructor(AbstractService, arguments);
   }
 

--- a/lib/classes/AbstractViewableService.js
+++ b/lib/classes/AbstractViewableService.js
@@ -18,7 +18,7 @@ var AbstractService = require('./AbstractService'),
  */
 function AbstractViewableService() {
 
-  if (!(this instanceof this)) {
+  if (!(this instanceof AbstractViewableService)) {
 		return applyConstructor(AbstractViewableService, arguments);
   }
 

--- a/lib/classes/AbstractViewableService.js
+++ b/lib/classes/AbstractViewableService.js
@@ -7,7 +7,9 @@
 
 
 // local modules
-var AbstractService = require('./AbstractService');
+var AbstractService = require('./AbstractService'),
+	applyConstructor = require('../utils/applyConstructor');
+
 
 
 /**
@@ -15,6 +17,11 @@ var AbstractService = require('./AbstractService');
  * @constructor
  */
 function AbstractViewableService() {
+
+  if (!(this instanceof this)) {
+		return applyConstructor(AbstractViewableService, arguments);
+  }
+
 	AbstractService.apply(this, arguments);
 	if (arguments.length !== 0) {
 		this.initScope();

--- a/lib/utils/applyConstructor.js
+++ b/lib/utils/applyConstructor.js
@@ -1,0 +1,24 @@
+/**
+ *
+ * @author Anthony Matarazzo <email@anthonymatarazzo.com>
+ */
+
+'use strict';
+
+/**
+ * applyConstructor returns a new instance of the provided constructor with the provided arguments applied.
+ * @function
+ */
+function applyConstructor(constructor, args) {
+	if (Object.prototype.toString.call(args) === '[object Arguments]') {
+		args = [].slice.call(args);
+	} else if (!(args instanceof Array)) {
+		args = [];
+	}
+
+	return new (Function.bind.apply(constructor, [null].concat(args)))();
+}
+
+
+
+module.exports = applyConstructor;


### PR DESCRIPTION
If the `new` keyword is ommitted by accident then `this` will be applied
to the outer scope and bad things can happen. This code creates a new
instance of the class with provided arguments if `this` is not an instance of the
respective constructor.

Add .editorconfig file.
